### PR TITLE
catch non-json exceptions and throw/reject appropriately

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -69,7 +69,12 @@ class Zabbix {
       if (res.result) {
         return res.result
       } else {
-        throw JSON.stringify(res)
+        try {
+          throw JSON.stringify(res)
+        }
+        catch(e) {
+          throw res
+        }
       }
     } catch (error) {
       throw error

--- a/lib/wrapper.js
+++ b/lib/wrapper.js
@@ -79,6 +79,7 @@ module.exports = {
              */
             res.resume()
             reject(error)
+            return
           }
 
           res.setEncoding('utf8')
@@ -86,7 +87,11 @@ module.exports = {
           res.on('data', (chunk) => { rawData = rawData + chunk })
           res.on('end', () => {
             debug('Response body: %o', rawData)
-            resolve(JSON.parse(rawData))
+            try {
+              resolve(JSON.parse(rawData))
+            } catch(e) {
+              resolve(rawData)
+            }
           })
         })
 


### PR DESCRIPTION
This catches errors correctly when JSON is not returned from the server (such as when you get 404s, 500s, etc)

fixes #21