### PR TITLE
add dummy id=1 to ever rq

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -63,7 +63,8 @@ class Zabbix {
         auth: this.auth,
         options: this.options,
         method,
-        params
+        params,
+        id: 1 //allways use 1 as dummy request id, since it is needed since zabbix 5.x api
       })
       debug('API Request response: %o', res)
       if (res.result) {


### PR DESCRIPTION
this seems to be necessary since zabbix 5.x api, otherwise the requests are no longer working